### PR TITLE
(minor) Fix link issue in Release configuration

### DIFF
--- a/overlay-sample/CMakeLists.txt
+++ b/overlay-sample/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(OverlaySample PRIVATE ${FREEIMAGEPLUS_LIBRARIES})
 
 set_target_properties(OverlaySample PROPERTIES FOLDER "Sample")
 set_target_properties(OverlaySample PROPERTIES CXX_STANDARD 17)
-target_link_libraries(OverlaySample PRIVATE debug openxr_loader${OPENXR_DEBUG_POSTFIX} optimized openxr)
+target_link_libraries(OverlaySample PRIVATE debug openxr_loader${OPENXR_DEBUG_POSTFIX} optimized openxr_loader)
 
 # Additional include directories
 set_property(TARGET OverlaySample


### PR DESCRIPTION
The link library was called `openxr` instead of `openxr_loader`